### PR TITLE
Added CSS so that Bootstrap Affix works on scroll

### DIFF
--- a/assets/sass/navigation.scss
+++ b/assets/sass/navigation.scss
@@ -100,6 +100,16 @@
   width: 170px !important;
   float: left !important;
   margin-top: 100px !important;
+
+  &.affix-top {
+    position: relative !important;
+  }
+
+  &.affix {
+    position: fixed !important;
+    top: 0;
+  }
+
   &.cortana-stick-bottom {
     position: fixed !important;
     top: 0px !important;


### PR DESCRIPTION
Without these two CSS classes, Bootstrap Affix would never actually work (the JS would be called, but the positioning wouldn't be triggered because of the !important declarations on this particular DOM element). Still need to dynamically calculate the width() of this DOM element so that it looks OK upon scrolling down (when taken to position:fixed)

Maybe I'm missing a spec somewhere? 
